### PR TITLE
`PhonopyData`: fix storing dataset in repository

### DIFF
--- a/src/aiida_phonopy/data/force_constants.py
+++ b/src/aiida_phonopy/data/force_constants.py
@@ -44,7 +44,7 @@ class ForceConstantsData(RawData):  # pylint: disable=too-many-ancestors
         ph_instance = super().get_phonopy_instance(**kwargs)
 
         if self.force_constants is not None:
-            ph_instance.set_force_constants(self.force_constants)
+            ph_instance.force_constants = self.force_constants
 
         return ph_instance
 

--- a/src/aiida_phonopy/data/preprocess.py
+++ b/src/aiida_phonopy/data/preprocess.py
@@ -156,7 +156,7 @@ class PreProcessData(RawData):  # pylint: disable=too-many-ancestors
         self._set_displacements(_serialize(copy.deepcopy(ph.dataset)))
 
     def get_phonopy_instance(self, symmetrize_nac=None, factor_nac=None, **kwargs):
-        """Return a `phonopy.Phonopy` object with the current values.
+        """Return a :class:`~phonopy.Phonopy` object with the current values.
 
         :param symmetrize_nac: whether or not to symmetrize the nac parameters using point group symmetry.
         :type symmetrize_nac: bool, defaults to self.is_symmetry

--- a/tests/data/test_phonopy_data.py
+++ b/tests/data/test_phonopy_data.py
@@ -13,7 +13,6 @@ def test_phonopy_attributes(generate_phonopy_data):
 @pytest.mark.usefixtures('aiida_profile')
 def test_phonopy_invalid_forces(generate_phonopy_data):
     """Test `PreProcessData` invalid forces."""
-
     message = 'the array is not of the correct shape'
 
     with pytest.raises(ValueError) as exception:


### PR DESCRIPTION
The `PhonopyData` was still using the database to
store the dislacements dataset information. This is now fixed to correctly store the dataset in the
repository.

I also improve some of the docstrings, and remove
a remaining warning.