### PR TITLE
DevOps: introduce `pydocstyle` in the precommit

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -121,13 +121,13 @@ jobs:
         -   name: Install flit
             run: pip install flit~=3.4
 
-        -   name: Build and publish to TestPyPI
-            run: flit publish --repository https://test.pypi.org/legacy/
-            env:
-                FLIT_USERNAME: __token__
-                FLIT_PASSWORD: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        # -   name: Build and publish to TestPyPI
+        #     run: flit publish --repository https://test.pypi.org/legacy/
+        #     env:
+        #         FLIT_USERNAME: __token__
+        #         FLIT_PASSWORD: ${{ secrets.TEST_PYPI_API_TOKEN }}
 
-        -   name: Build and publish to PyPI
+        -   name: Build and publish
             run: flit publish
             env:
                 FLIT_USERNAME: __token__

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,3 +34,14 @@ repos:
         entry: pylint
         types: [python]
         language: system
+
+-   repo: https://github.com/PyCQA/pydocstyle
+    rev: '6.1.1'
+    hooks:
+    -   id: pydocstyle
+        exclude: >
+            (?x)^(
+                docs/.*|
+                tests/.*(?<!\.py)$
+            )$
+        additional_dependencies: ['toml']

--- a/src/aiida_phonopy/calculations/functions/link_structures.py
+++ b/src/aiida_phonopy/calculations/functions/link_structures.py
@@ -1,17 +1,19 @@
 # -*- coding: utf-8 -*-
 """Functions for linking PhonopyAtoms and StructureData."""
+from __future__ import annotations
+
+from aiida.orm import StructureData
+from phonopy.structure.cells import PhonopyAtoms
 
 __all__ = ('phonopy_atoms_to_structure', 'phonopy_atoms_from_structure', 'if_to_map')
 
 
-def phonopy_atoms_to_structure(cell, mapping=None):
+def phonopy_atoms_to_structure(cell: PhonopyAtoms, mapping: dict | None = None) -> StructureData:
     """Return a StructureData from a PhonopyAtoms instance.
 
     :param cell: a PhonopyAtoms instance
     :param mapping: a number to kinds and symbols map, defaults to None
     """
-    from aiida import orm
-
     if mapping:
         numbers_to_kinds, numbers_to_symbols = mapping
         symbols = []
@@ -31,21 +33,22 @@ def phonopy_atoms_to_structure(cell, mapping=None):
     positions = cell.positions
     masses = cell.masses
 
-    structure = orm.StructureData(cell=cell.cell)
+    structure = StructureData(cell=cell.cell)
     for position, symbol, name, mass in zip(positions, symbols, names, masses):
         structure.append_atom(position=position, symbols=symbol, name=name, mass=mass)
 
     return structure
 
 
-def phonopy_atoms_from_structure(structure):
+def phonopy_atoms_from_structure(structure: StructureData) -> PhonopyAtoms:
     """Return a tuple containg the PhonopyAtoms and the mapping from a StructureData.
 
     :param structure: StructureData instance
-    :return: it returns a PhonopyAtoms istance and the mapping
+    :return: tuple with element:
+        * a :class:`~phonopy.structure.cells.PhonopyAtoms` istance
+        * mapping dictionary, with key:pair of the type int:str, string
+            referring to the custom atomic name
     """
-    from phonopy.structure.cells import PhonopyAtoms
-
     to_map = if_to_map(structure)
 
     if not to_map:  # when kind_names=symbols are used in the structure
@@ -93,10 +96,11 @@ def phonopy_atoms_from_structure(structure):
     return (cell, [numbers_to_kinds, numbers_to_symbols])
 
 
-def if_to_map(structure):
+def if_to_map(structure: StructureData) -> bool:
     """Return a bool according whether kind names and symbols are the same.
 
     :param structure: StructureData instance
+
     :return: True if kind names different from symbols are used, False otherwise
     """
     check_kinds = [True for kind in structure.kinds if kind.name != kind.symbol]

--- a/src/aiida_phonopy/calculations/phonopy.py
+++ b/src/aiida_phonopy/calculations/phonopy.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 """CalcJob for phonopy post-processing."""
-
 from aiida import orm
 from aiida.common import InputValidationError, datastructures
 from aiida.engine import CalcJob
@@ -274,7 +273,7 @@ class PhonopyCalculation(CalcJob):
         lists that are to be retrieved after job completion.
 
         :param folder: a sandbox folder to temporarily write files on disk.
-        :return: :py:`~aiida.common.datastructures.CalcInfo` instance.
+        :return: :py:class:`~aiida.common.datastructures.CalcInfo` instance.
         """
         retrieve_list = []
         retrieve_temporary_list = []

--- a/src/aiida_phonopy/parsers/base.py
+++ b/src/aiida_phonopy/parsers/base.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
-"""Defines a `Parser` base class for `aiida-phonopy`.
-
-All `Parser` implementations in `aiida-phonopy` must use this base class, not `aiida.parsers.Parser`.
-"""
+"""Defines a `Parser` base class for `aiida-phonopy`."""
+# All `Parser` implementations in `aiida-phonopy` must use this base class, not `aiida.parsers.Parser`.
 from aiida.parsers import Parser as _BaseParser
 
 __all__ = ('Parser',)

--- a/src/aiida_phonopy/parsers/phonopy.py
+++ b/src/aiida_phonopy/parsers/phonopy.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Parsers of `PhonopyCalculation` output files."""
+from __future__ import annotations
 
 import os
 import traceback
@@ -15,8 +16,8 @@ from aiida_phonopy.utils.mapping import _uppercase_dict, get_logging_container
 from .base import Parser
 
 
-def file_opener(folder_path, filename):
-    """Function to open sistematically each expected output format."""
+def file_opener(folder_path: str, filename: str):
+    """Return a function to open different expected output format."""
     filename_path = os.path.join(folder_path, filename)
 
     if filename.endswith('hdf5'):
@@ -127,7 +128,7 @@ class PhonopyParser(Parser):
         # if filenames:
         #     self.exit_codes.ERROR_NOT_IMPLEMENTED_PARSER
 
-    def parse_stdout(self):
+    def parse_stdout(self) -> tuple:
         """Parse the stdout output file.
 
         :param parameters: the input parameters dictionary
@@ -172,7 +173,7 @@ class PhonopyParser(Parser):
 
         return parsed_data, logs, exit_code_stdout
 
-    def get_expected_filenames_keys(self):
+    def get_expected_filenames_keys(self) -> set:
         """Return the retrieve file keys (that map to the filenames outputs) depending on the tags in `parameters`."""
         retrieved_set = set()
         parameters = _uppercase_dict(self.node.inputs.parameters.get_dict(), dict_name='parameters')
@@ -214,7 +215,7 @@ class PhonopyParser(Parser):
 
         return retrieved_set
 
-    def parse_force_constants(self, filepath):
+    def parse_force_constants(self, filepath: str) -> orm.ArrayData:
         """Parse the `force_constants.hdf5` output file."""
         from phonopy.file_IO import read_force_constants_hdf5
 
@@ -227,7 +228,7 @@ class PhonopyParser(Parser):
 
         return fc_array
 
-    def load_with_numpy(self, file):
+    def load_with_numpy(self, file: str) -> np.ndarray:
         """Load a txt file using numpy."""
         try:
             data = np.loadtxt(file)
@@ -235,7 +236,7 @@ class PhonopyParser(Parser):
             self.exit(self.exit_codes.ERROR_OUTPUT_NUMPY_LOAD)
         return data
 
-    def load_with_yaml(self, file):
+    def load_with_yaml(self, file: str) -> dict:
         """Load a yaml file using."""
         try:
             data = yaml.safe_load(file)
@@ -243,12 +244,12 @@ class PhonopyParser(Parser):
             self.exit(self.exit_codes.ERROR_OUTPUT_YAML_LOAD)
         return data
 
-    def parse_yaml(self, file):
+    def parse_yaml(self, file: str) -> orm.Dict:
         """Parse a `.yaml` file and return it as a Dict."""
         data = self.load_with_yaml(file=file)
         return orm.Dict(data)
 
-    def parse_total_dos(self, file):
+    def parse_total_dos(self, file: str) -> orm.XyData:
         """Parse `total_dos.dat` output file."""
         data = self.load_with_numpy(file=file)
 
@@ -260,7 +261,7 @@ class PhonopyParser(Parser):
 
         return dos
 
-    def parse_projected_dos(self, file):
+    def parse_projected_dos(self, file: str) -> orm.XyData:
         """Parse `projected_dos.dat` output file."""
         data = self.load_with_numpy(file=file)
 
@@ -281,7 +282,7 @@ class PhonopyParser(Parser):
 
         return pdos
 
-    def parse_thermal_properties(self, file):
+    def parse_thermal_properties(self, file: str) -> orm.XyData:
         """Parse the `thermal_properties.yaml`` output file."""
         data = self.load_with_yaml(file=file)
 
@@ -316,7 +317,7 @@ class PhonopyParser(Parser):
 
         return tprops
 
-    def parse_band_structure(self, file, freqs_units='THz'):
+    def parse_band_structure(self, file: str, freqs_units: str = 'THz') -> orm.BandsData:
         """Parse the `band.hdf5`` output file.
 
         Expected keys are:
@@ -389,7 +390,7 @@ class PhonopyParser(Parser):
 
         return band_structure
 
-    def parse_qpoints(self, file, freqs_units='THz'):
+    def parse_qpoints(self, file: str, freqs_units: str = 'THz') -> orm.BandsData:
         """Parse the `mesh.hdf5`` and `qpoints.hdf5`` output files.
 
         Expected keys are:

--- a/src/aiida_phonopy/utils/mapping.py
+++ b/src/aiida_phonopy/utils/mapping.py
@@ -22,7 +22,8 @@ def get_logging_container():
     })
 
 
-def _case_transform_dict(dictionary, dict_name, func_name, transform):
+def _case_transform_dict(dictionary: dict, dict_name: str, func_name, transform):
+    """Transform a dictionary to have the first keys capitalized or decapitalized."""
     from collections import Counter
 
     from aiida.common import InputValidationError
@@ -42,9 +43,11 @@ def _case_transform_dict(dictionary, dict_name, func_name, transform):
     return new_dict
 
 
-def _lowercase_dict(dictionary, dict_name):
+def _lowercase_dict(dictionary: dict, dict_name: str):
+    """Transform a dictionary to have the first keys decapitalized."""
     return _case_transform_dict(dictionary, dict_name, '_lowercase_dict', str.lower)
 
 
-def _uppercase_dict(dictionary, dict_name):
+def _uppercase_dict(dictionary: dict, dict_name: str):
+    """Transform a dictionary to have the first keys capitalized."""
     return _case_transform_dict(dictionary, dict_name, '_uppercase_dict', str.upper)

--- a/src/aiida_phonopy/workflows/phonopy.py
+++ b/src/aiida_phonopy/workflows/phonopy.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 """Abstract workflow for automatic frozen phonons calculations."""
-
 from abc import ABCMeta
 
 from aiida import orm
@@ -70,10 +69,10 @@ def validate_inputs(inputs, _):
 
 
 class PhonopyWorkChain(WorkChain, metaclass=ABCMeta):
-    """
-    Abstract Workflow to compute automatically the force sets and force constants
-    of a given structure using the frozen phonons approach. Phonopy is used to produce
-    structures with displacements, while the forces are calculated with a quantum engine of choice.
+    """Abstract workflow for automated frozen phonons.
+
+    Phonopy is used to produce structures with displacements,
+    while the forces are calculated with a quantum engine of choice.
 
     This workchain is meant to be used as a base for other specific force calculato plugin workchains,
     or as an example on how to set a possible workchain/workflow. For this reason, the outline of
@@ -167,7 +166,7 @@ class PhonopyWorkChain(WorkChain, metaclass=ABCMeta):
         want, for some reason, compute the nac on the unitcell, you will need to get the reduced nac.
         To do so, you can consider using a built-in function in phonopy, namely:
 
-        ```phonopy.structure.symmetry.elaborate_borns_and_epsilon```
+        :py:func:`phonopy.structure.symmetry.elaborate_borns_and_epsilon`
 
     """
 
@@ -347,7 +346,7 @@ class PhonopyWorkChain(WorkChain, metaclass=ABCMeta):
                 return f'Displacement options must be of the correct type; got invalid values {invalid_values}.'
 
     def setup(self):
-        """Setup the workflow generating the PreProcessData."""
+        """Set up the workflow generating the PreProcessData."""
         if 'preprocess_data' in self.inputs:
             preprocess = self.inputs.preprocess_data
             if 'displacement_generator' in self.inputs:


### PR DESCRIPTION
To make documentation of the code more readable,
I introduce in the pre-commit file the pydocstyle hook. 
All files are documented addressing the hook, and
typing is used as much as possible.