### PR TITLE
`PhonopyCalculation`: fix `force_constants`

### DIFF
--- a/src/aiida_phonopy/calculations/phonopy.py
+++ b/src/aiida_phonopy/calculations/phonopy.py
@@ -325,7 +325,7 @@ class PhonopyCalculation(CalcJob):
         for value in self._OUTPUTS.values():
             retrieve_temporary_list.append(value[0])  # first value of the tuple
         if 'force_constants' in self.inputs:  # otherwise we retrieve the same thing as the input
-            retrieve_temporary_list.pop(self._INPUT_FORCE_CONSTANTS)
+            retrieve_temporary_list.remove(self._INPUT_FORCE_CONSTANTS)
 
         # ============================ calcinfo ===============================
 

--- a/tests/calculations/test_phonopy.py
+++ b/tests/calculations/test_phonopy.py
@@ -77,6 +77,46 @@ def test_phonopy_default(fixture_sandbox, generate_calc_job, generate_inputs):
     assert len(calc_info.codes_info) == 1
 
 
+def test_phonopy_with_fc(fixture_sandbox, generate_calc_job, generate_inputs, generate_force_constants):
+    """Test a `PhonopyCalculation` with force constants."""
+    entry_point_name = 'phonopy.phonopy'
+    inputs = generate_inputs()
+    inputs.pop('phonopy_data')
+    inputs['force_constants'] = generate_force_constants()
+
+    calc_info = generate_calc_job(fixture_sandbox, entry_point_name, inputs)
+
+    raw_inputs = ['phonopy.yaml', 'aiida.in']
+    retrieve_temporary_list = [
+        'phonopy.yaml',
+        'band.hdf5',
+        'qpoints.hdf5',
+        'mesh.hdf5',
+        'irreps.yaml',
+        'thermal_properties.yaml',
+        'thermal_displacements.yaml',
+        'thermal_displacement_matrices.yaml',
+        'modulation.yaml',
+        'total_dos.dat',
+        'projected_dos.dat',
+    ]
+    retrieve_list = ['aiida.out']
+
+    # Check the attributes of the returned `CalcInfo`
+    assert isinstance(calc_info, datastructures.CalcInfo)
+    assert len(calc_info.local_copy_list) == 0
+
+    assert len(calc_info.retrieve_list) == len(retrieve_list)
+    assert sorted(calc_info.retrieve_list) == sorted(retrieve_list)
+
+    assert len(calc_info.retrieve_temporary_list) == len(retrieve_temporary_list)
+    assert sorted(calc_info.retrieve_temporary_list) == sorted(retrieve_temporary_list)
+
+    # Checks on the files written to the sandbox folder as raw input
+    assert sorted(fixture_sandbox.get_content_list()) == sorted(raw_inputs + ['force_constants.hdf5'])
+    assert len(calc_info.codes_info) == 1
+
+
 def test_phonopy_cmdsline(fixture_sandbox, generate_calc_job, generate_inputs):
     """Test a `PhonopyCalculation` with user-defined cmdline from `parameters`."""
     entry_point_name = 'phonopy.phonopy'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -408,6 +408,38 @@ def generate_example_phonopy_data():
 
 
 @pytest.fixture
+def generate_force_constants():
+    """Return BTO ForceConstantsData."""
+
+    def _generate_force_constants():
+        """Return BTO ForceConstantsData."""
+        import os
+
+        import phonopy
+
+        from aiida_phonopy.data import ForceConstantsData
+
+        basepath = os.path.dirname(os.path.abspath(__file__))
+        phyaml = os.path.join(basepath, 'fixtures', 'phonopy', 'phonopy.yaml')
+        fsets = os.path.join(basepath, 'fixtures', 'phonopy', 'FORCE_SETS')
+
+        ph = phonopy.load(phyaml, force_sets_filename=fsets)
+        ph.produce_force_constants()
+
+        fc_data = ForceConstantsData(
+            phonopy_atoms=ph.unitcell,
+            supercell_matrix=ph.supercell_matrix,
+            primitive_matrix=ph.primitive_matrix,
+            symprec=ph.symmetry.tolerance,
+        )
+        fc_data.set_force_constants(ph.force_constants)
+
+        return fc_data
+
+    return _generate_force_constants
+
+
+@pytest.fixture
 def generate_remote_data():
     """Return a `RemoteData` node."""
 


### PR DESCRIPTION
A typo was present when `force_constants` was set in inputs. A test is added to check this does not occur.