### PR TITLE
`CI`: add `codecov` after the test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
                 -   python-version: '3.9'
                     phonopy-version: '2.19.0'
                 -   python-version: '3.10'
-                    phonopy-version: '2.20.0'
+                    phonopy-version: '2.21.0'
 
         services:
             rabbitmq:
@@ -80,4 +80,13 @@ jobs:
         -   name: Run pytest
             env:
                 AIIDA_WARN_v3: 1
-            run: pytest -sv tests
+            run: pytest -sv --cov aiida_phonopy tests
+
+        -   name: Upload to Codecov
+            if: matrix.python-version == 3.10
+            uses: codecov/codecov-action@v3
+            with:
+                token: ${{ secrets.CODECOV_TOKEN }}
+                name: pytests-phonopy3.10
+                flags: pytests
+                fail_ci_if_error: true

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,0 +1,10 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 70%
+        threshold: 1%
+    patch:
+      default:
+        target: 65%
+        threshold: 0.2%

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,10 +43,13 @@ pre-commit = [
     'toml',
 ]
 tests = [
+    'ase',
     'pgtest~=1.3',
     'pytest~=6.0',
+    'coverage[toml]',
+    'pytest-cov',
     'pytest-regressions~=2.3',
-    'ase',
+    'pytest-timeout',
 ]
 docs = [
     'myst-nb~=1.0.0rc0',


### PR DESCRIPTION
Code coverage is a powerful tool to have insights on how many lines of code are covered by the test suite. A reasonable threshold of 70% should maintain the quality of the code.